### PR TITLE
fix travis build (#333)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ matrix:
     - env: CABALVER=1.24 GHCVER=8.0.2
       compiler: ": #GHC 8.0.2"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5], sources: [hvr-ghc]}}
-    - env: CABALVER=2.0 GHCVER=8.2.1
-      compiler: ": #GHC 8.2.1"
-      addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.1,happy-1.19.5], sources: [hvr-ghc]}}
+    - env: CABALVER=2.0 GHCVER=8.2.2
+      compiler: ": #GHC 8.2.2"
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.5], sources: [hvr-ghc]}}
 
 before_install:
  - unset CC

--- a/duckling.cabal
+++ b/duckling.cabal
@@ -24,7 +24,7 @@ stability:           alpha
 cabal-version:       >=1.10
 tested-with:
   GHC==8.0.2,
-  GHC==8.2.1
+  GHC==8.2.2
 
 extra-source-files:    README.md
                      , PATENTS


### PR DESCRIPTION
Summary:
Fixes the travis build by raising the ghc version from 8.2.1 to 8.2.2 which according to the logs failed due to an ghc bug
Pull Request resolved: https://github.com/facebook/duckling/pull/333

Differential Revision: D14145462

Pulled By: patapizza

fbshipit-source-id: b734cf75d7b31e49503fc87dee0125455adedabe